### PR TITLE
CheckRebootHygiene Actor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,162 @@
+repos/**/.leapp/leapp.db
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/repos/system_upgrade_supplements/common/.leapp/info
+++ b/repos/system_upgrade_supplements/common/.leapp/info
@@ -1,0 +1,1 @@
+{"repos": ["644900a5-c347-43a3-bfab-f448f46d9647"], "name": "system_upgrade_supplements_common", "id": "4c8f7c9a-c983-4d28-965a-8d3e0a8b443b"}

--- a/repos/system_upgrade_supplements/common/.leapp/leapp.conf
+++ b/repos/system_upgrade_supplements/common/.leapp/leapp.conf
@@ -1,0 +1,6 @@
+
+[repositories]
+repo_path=${repository:root_dir}
+
+[database]
+path=${repository:state_dir}/leapp.db

--- a/repos/system_upgrade_supplements/common/actors/checkreboothygiene/actor.py
+++ b/repos/system_upgrade_supplements/common/actors/checkreboothygiene/actor.py
@@ -1,0 +1,34 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import checkreboothygiene
+from leapp.reporting import Report
+# from leapp.tags import ChecksPhaseTag
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+from leapp.models import InstalledRedHatSignedRPM
+
+
+class CheckRebootHygiene(Actor):
+    """
+    The CheckRebootHygiene actor will report an inhibitor in case of conditions
+    that may be prohibited by an organization's reboot hygiene policy.
+
+    The actor will report inhibitor risk when:
+    * The host uptime is greater than the maximum defined by the policy.
+    * The running kernel version does not match the default kernel version
+      configured in the bootloader.
+    * Any files are found under /boot that have been modified since the last reboot.
+    """
+
+    name = "check_reboot_hygiene"
+    consumes = ()
+    produces = (Report,)
+    tags = (ChecksPhaseTag,)
+
+    def process(self):
+        self.log.info("Checking reboot hygiene")
+        self.log.info("Checking for excessive uptime")
+        checkreboothygiene.check_excessive_uptime()
+        self.log.info("Checking for mismatched kernel versions")
+        checkreboothygiene.check_mismatched_kernel_versions()
+        self.log.info("Checking for modified boot files")
+        checkreboothygiene.check_modified_boot_files()
+        self.log.info("Reboot hygiene check complete")

--- a/repos/system_upgrade_supplements/common/actors/checkreboothygiene/libraries/checkreboothygiene.py
+++ b/repos/system_upgrade_supplements/common/actors/checkreboothygiene/libraries/checkreboothygiene.py
@@ -1,0 +1,115 @@
+import os
+import time
+
+from leapp import reporting
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.common import config
+from leapp.libraries.stdlib import CalledProcessError, api, run
+
+DAY_IN_SECONDS = 24 * 60 * 60
+# TODO: can this be parametrized? (Makefile)
+EXCESSIVE_UPTIME_LIMIT_DAYS = 30
+EXCESSIVE_UPTIME_LIMIT_SECONDS = EXCESSIVE_UPTIME_LIMIT_DAYS * DAY_IN_SECONDS
+
+FMT_LIST_SEPARATOR = "\n    - "
+
+def check_excessive_uptime():
+    uptime_seconds = _get_uptime()
+
+    if uptime_seconds > EXCESSIVE_UPTIME_LIMIT_SECONDS:
+        summary = (
+            "This host has not been rebooted for over {} days. "
+            "To reduce the risk of boot issues related to any changes made since the last reboot, "
+            "policy requires the host to be rebooted before going forward with the upgrade."
+        ).format(EXCESSIVE_UPTIME_LIMIT_DAYS)
+
+        report = [
+            reporting.Title("Excessive uptime detected"),
+            reporting.Summary(summary),
+            reporting.Severity(reporting.Severity.HIGH),
+            reporting.Groups([reporting.Groups.SANITY, reporting.Groups.INHIBITOR]),
+            reporting.Remediation(hint="Please reboot the host machine."),
+        ]
+        reporting.create_report(report)
+
+
+def _get_uptime():
+    """
+    Get system uptime in seconds.
+
+    :returns: Uptime in seconds
+    :rtype: float
+    """
+    with open("/proc/uptime", "r") as f:
+        uptime_seconds = float(f.readline().split()[0])
+    return uptime_seconds
+
+
+def check_mismatched_kernel_versions():
+    running_kernel_version = api.current_actor().configuration.kernel
+
+    # Get default kernel version
+    try:
+        default_kernel_version = run(["grubby", "--default-kernel"])["stdout"].strip()
+        # Remove the /boot/vmlinuz- prefix from the path
+        default_kernel_version = os.path.basename(default_kernel_version).split("-", 1)[1]
+    except (OSError, CalledProcessError):
+        api.current_logger().warning("Failed to query grubby for default kernel", exc_info=True)
+        return
+
+    if running_kernel_version != default_kernel_version:
+        summary = (
+            "This host is running different kernel version ({}) than the default kernel version ({}) configured "
+            "in the bootloader. Maybe a new kernel version was installed without then rebooting the host? "
+            "Policy requires the host to be rebooted before going forward with the upgrade."
+        ).format(running_kernel_version, default_kernel_version)
+
+        kernel_versions_related = [
+            reporting.RelatedResource("default_kernel_version", default_kernel_version),
+            reporting.RelatedResource("running_kernel_version", running_kernel_version),
+        ]
+
+        report = [
+            reporting.Title("Mismatched kernel versions detected"),
+            reporting.Summary(summary),
+            reporting.Severity(reporting.Severity.HIGH),
+            reporting.Groups([reporting.Groups.SANITY, reporting.Groups.INHIBITOR]),
+            reporting.Remediation(hint="Please reboot the host machine."),
+        ] + kernel_versions_related
+        reporting.create_report(report)
+
+
+def check_modified_boot_files():
+    boot_files = []
+    for root, _, files in os.walk("/boot"):
+        for file in files:
+            file_path = os.path.join(root, file)
+            if os.path.isfile(file_path):
+                boot_files.append(file_path)
+
+    modified_boot_files = []
+    uptime_seconds = _get_uptime()
+    for file in boot_files:
+        if os.stat(file).st_mtime > time.time() - uptime_seconds:
+            modified_boot_files.append(file)
+
+    if modified_boot_files:
+        sorted_boot_files = sorted(modified_boot_files)
+        summary = (
+            "Some files on the /boot partition have been modified since the last reboot. "
+            "To reduce the risk of boot issues related to changes made since the last reboot, "
+            "policy requires the host to be rebooted before going forward with the upgrade."
+            "The following files have been modified:{}{}"
+            .format(FMT_LIST_SEPARATOR, FMT_LIST_SEPARATOR.join(sorted_boot_files))
+        )
+
+        boot_files_related = [reporting.RelatedResource("file", f) for f in sorted_boot_files]
+
+        report = [
+            reporting.Title("Modified files under /boot detected"),
+            reporting.Summary(summary),
+            reporting.Severity(reporting.Severity.HIGH),
+            reporting.Groups([reporting.Groups.SANITY, reporting.Groups.INHIBITOR]),
+            reporting.Remediation(hint="Please reboot the host machine."),
+        ] + boot_files_related
+        reporting.create_report(report)

--- a/repos/system_upgrade_supplements/common/actors/checkreboothygiene/tests/unit_test_checkreboothygiene.py
+++ b/repos/system_upgrade_supplements/common/actors/checkreboothygiene/tests/unit_test_checkreboothygiene.py
@@ -1,0 +1,74 @@
+import os
+import time
+
+import mock
+import pytest
+from leapp import reporting
+from leapp.libraries.actor import checkreboothygiene
+from leapp.libraries.actor.checkreboothygiene import EXCESSIVE_UPTIME_LIMIT_SECONDS
+from leapp.libraries.common.testutils import create_report_mocked, CurrentActorMocked
+from leapp.utils.report import is_inhibitor
+from leapp.libraries.stdlib import api
+
+KERNEL_VERSION_1 = "3.10.0-1062.1.2.el7.x86_64"
+KERNEL_VERSION_2 = "3.10.0-1160.88.1.el7.x86_64"
+
+
+def assert_inhibitor(should_inhibit):
+    if should_inhibit:
+        reporting.create_report.called
+        assert is_inhibitor(reporting.create_report.report_fields)
+    else:
+        assert not reporting.create_report.called
+
+
+@pytest.mark.parametrize(
+    "uptime, inhibit",
+    (
+        (0, False),
+        (EXCESSIVE_UPTIME_LIMIT_SECONDS, False),
+        (EXCESSIVE_UPTIME_LIMIT_SECONDS + 1, True),
+    ),
+)
+def test_excessive_uptime(uptime, inhibit, monkeypatch):
+    monkeypatch.setattr(reporting, "create_report", create_report_mocked())
+    monkeypatch.setattr(checkreboothygiene, "_get_uptime", lambda: uptime)
+    checkreboothygiene.check_excessive_uptime()
+    assert_inhibitor(inhibit)
+
+
+@pytest.mark.parametrize(
+    "booted_kernel, default_kernel, inhibit",
+    (
+        (KERNEL_VERSION_1, KERNEL_VERSION_1, False),
+        (KERNEL_VERSION_1, KERNEL_VERSION_2, True),
+    ),
+)
+def test_mismatched_kernel_versions(booted_kernel, default_kernel, inhibit, monkeypatch):
+    monkeypatch.setattr(reporting, "create_report", create_report_mocked())
+    monkeypatch.setattr(api, "current_actor", CurrentActorMocked(kernel=booted_kernel))
+    monkeypatch.setattr(checkreboothygiene, "run", lambda _: {"stdout": "/boot/vmlinuz-" + default_kernel})
+    checkreboothygiene.check_mismatched_kernel_versions()
+    assert_inhibitor(inhibit)
+
+
+@pytest.mark.parametrize(
+    "uptime_seconds, since_modified_seconds, inhibit",
+    (
+        (0, 1, False),
+        (0, 3600, False),
+        (3600, 0, True),
+        (3601, 3600, True),
+    ),
+)
+def test_modified_boot_files(uptime_seconds, since_modified_seconds, inhibit, monkeypatch):
+    monkeypatch.setattr(reporting, "create_report", create_report_mocked())
+    monkeypatch.setattr(os, "walk", lambda _: [("/boot", [], ["file1", "file2"])])
+    monkeypatch.setattr(os.path, "isfile", lambda _: True)
+
+    monkeypatch.setattr(checkreboothygiene, "_get_uptime", lambda: uptime_seconds)
+    with mock.patch("os.stat") as mocked_stat:
+        mocked_stat.return_value.st_mtime = time.time() - since_modified_seconds
+        checkreboothygiene.check_modified_boot_files()
+
+    assert_inhibitor(inhibit)

--- a/repos/system_upgrade_supplements/el7toel8/.leapp/info
+++ b/repos/system_upgrade_supplements/el7toel8/.leapp/info
@@ -1,0 +1,1 @@
+{"repos": ["c47fbc3d-ae38-416e-9176-7163d67d94f6", "4c8f7c9a-c983-4d28-965a-8d3e0a8b443b"], "name": "system_upgrade_supplements_el7toel8", "id": "e3862038-cf52-49d4-b3a4-de8fe0e908b8"}

--- a/repos/system_upgrade_supplements/el7toel8/.leapp/leapp.conf
+++ b/repos/system_upgrade_supplements/el7toel8/.leapp/leapp.conf
@@ -1,0 +1,6 @@
+
+[repositories]
+repo_path=${repository:root_dir}
+
+[database]
+path=${repository:state_dir}/leapp.db

--- a/repos/system_upgrade_supplements/el8toel9/.leapp/info
+++ b/repos/system_upgrade_supplements/el8toel9/.leapp/info
@@ -1,0 +1,1 @@
+{"repos": ["ec300ca1-d0e1-46d7-a2d2-6030dcc1864a", "4c8f7c9a-c983-4d28-965a-8d3e0a8b443b"], "name": "system_upgrade_supplements_el8toel9", "id": "50a487f7-5d8e-49a1-8d71-108da51358c3"}

--- a/repos/system_upgrade_supplements/el8toel9/.leapp/leapp.conf
+++ b/repos/system_upgrade_supplements/el8toel9/.leapp/leapp.conf
@@ -1,0 +1,6 @@
+
+[repositories]
+repo_path=${repository:root_dir}
+
+[database]
+path=${repository:state_dir}/leapp.db


### PR DESCRIPTION
OAMG-8806

DONE:
- uptime check
- mismatched kernel versions check
- files modified in /boot since last reboot check
- tests for all checks

**Repo structure**

Custom actors are located under `"repos/system_upgrade_supplements/{common, el7toel8, el8toel9}"`. The `common`, `el7toel8`, and `el8toel9` are leapp repositories (.leapp files). They are linked to the respective repositories in [leapp-repository](https://github.com/oamg/leapp-repository) (under `system_upgrade`). Additionally, `el7toel8` and `el8toel9` repos are linked to the `common` supplements repository.


Questions
- should uptime have its own model and actor? Similarly for kernel versions + boot file
  - not needed / should not be done for this repository. We want to install individual actors so introducing actor dependencies would make the process harder.