### PR TITLE
 Add custom actor RPM packaging and build instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ __pycache__/
 *.so
 
 # Distribution / packaging
+packaging/*/
+*.rpm
 .Python
 build/
 develop-eggs/
@@ -32,7 +34,6 @@ MANIFEST
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
-*.spec
 
 # Installer logs
 pip-log.txt

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,201 @@
-MIT License
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2023 Leapp team
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,55 @@
+DIST_VERSION ?= 7
+
+PKGNAME := leapp-supplements
+VERSION=$(shell grep -m1 "^Version:" packaging/$(PKGNAME).spec | grep -om1 "[0-9].[0-9.]*")
+SPEC_FILE := $(PKGNAME).spec
+TARBALL_PREFIX := $(PKGNAME)-$(VERSION)
+TARBALL := $(TARBALL_PREFIX).tar.gz
+ACTORS_TO_INSTALL := $(shell grep -v '^\#' actor-list.txt | tr '\n' ' ')
+
+.PHONY: help clean tarball rpmbuild
+
+help:
+	@echo "Available targets:"
+	@echo "  rpmbuild   : Build RPM packages of the custom actors"
+	@echo "  tarball    : Create a tarball of the source code from the current git HEAD"
+	@echo "  clean      : Clean build artifacts and temporary files"
+	@echo "  help       : Show this help message"
+	@echo ""
+	@echo "To build an RPM for RHEL7 upgrade, run:"
+	@echo "  make rpmbuild DIST_VERSION=7"
+	@echo "To build an RPM for RHEL8 upgrade, run:"
+	@echo "  make rpmbuild DIST_VERSION=8"
+	@echo ""
+	@echo "Make sure to customize the actor-list.txt before building the RPM!"
+
+rpmbuild: prepare
+	rpmbuild -ba packaging/$(SPEC_FILE) \
+		--define "_topdir $(shell pwd)/packaging" \
+		--define "pkgname $(PKGNAME)" \
+		--define "rhel $(DIST_VERSION)" \
+		--define "nextrhel $$(($(DIST_VERSION) + 1))" \
+		--define "dist .el$(DIST_VERSION)" \
+		--define "actors_to_install $(ACTORS_TO_INSTALL)"
+	cp packaging/RPMS/*/*.rpm .
+	cp packaging/SRPMS/*.rpm .
+
+tarball:
+	git archive --format=tar.gz --prefix=$(TARBALL_PREFIX)/ -o $(TARBALL) HEAD
+
+prepare: check_actor_list clean tarball
+# create the build directories
+	mkdir -p packaging/{BUILD,RPMS,SOURCES,SRPMS,BUILDROOT}
+	mv $(TARBALL) packaging/SOURCES/
+
+# check if there are any actors in ACTORS_TO_INSTALL, exit if not
+check_actor_list:
+	@[ -n "$(ACTORS_TO_INSTALL)" ] || (echo "[ERR] actor-list.txt cannot be empty, no actors to install" && exit 1)
+
+clean:
+	rm -rf packaging/{BUILD,RPMS,SOURCES,SRPMS,BUILDROOT}
+	rm -f *.rpm *tar.gz
+	find . -name 'leapp.db' | grep "\.leapp/leapp.db" | xargs rm -f
+	find . -name '__pycache__' -exec rm -fr {} +
+	find . -name '*.pyc' -exec rm -f {} +
+	find . -name '*.pyo' -exec rm -f {} +

--- a/README.md
+++ b/README.md
@@ -1,6 +1,113 @@
 # leapp-supplements
-Supplementary Content for leapp upgrades, such as 
-* Ansible Roles
-* Ansible Playbooks
-* Custom Leapp Actors for handling common 3rd party things
 
+This repository contains custom actors for the Leapp project that enable in-place upgrades to the next major version of the Red Hat Enterprise Linux system.
+It aims to handle common 3rd party use cases during the upgrade process.
+
+## Table of Contents
+- [leapp-supplements](#leapp-supplements)
+  - [Table of Contents](#table-of-contents)
+  - [Actor list](#actor-list)
+  - [Actor description](#actor-description)
+    - [CheckRebootHygiene](#checkreboothygiene)
+  - [Building the Custom Actors RPM](#building-the-custom-actors-rpm)
+    - [Prerequisites](#prerequisites)
+    - [Building the RPM](#building-the-rpm)
+    - [Installing the RPM](#installing-the-rpm)
+    - [Using the Custom Actors](#using-the-custom-actors)
+  - [Contributing](#contributing)
+
+## Actor list
+
+The following actors are currently available in this repository:
+- checkreboothygiene
+
+These actors are listed in [`actor-list.txt`](./actor-list.txt) file by default.
+
+## Actor description
+
+### CheckRebootHygiene
+
+The CheckRebootHygiene actor will report an inhibitor in case of conditions
+that may be prohibited by an organization's reboot hygiene policy.
+
+The actor will report inhibitor risk when:
+* The host uptime is greater than the maximum defined by the policy.
+* The running kernel version does not match the default kernel version configured in the bootloader.
+* Any files are found under /boot that have been modified since the last reboot.
+
+## Building the Custom Actors RPM
+
+In order to bundle the custom actors from this Git repository, follow the instructions below.
+
+### Prerequisites
+
+- A system running Red Hat Enterprise Linux 7 or 8
+- `git` installed on your system
+- `make` package installed
+- `rpm-build` package installed
+- Appropriate Python development package
+
+You can install these prerequisites by running the following command:
+
+- On RHEL 7:
+
+    ```bash
+    sudo yum install git make rpm-build python2-devel
+    ```
+
+- On RHEL 8:
+
+    ```bash
+    sudo dnf install git make rpm-build python3-devel
+    ```
+
+### Building the RPM
+
+1. Clone the repository to your local machine:
+```bash
+git clone https://github.com/oamg/leapp-supplements.git
+```
+
+2. Change to the `leapp-supplements` directory:
+```bash
+cd leapp-supplements
+```
+
+3. Ensure the `actor-list.txt` file contains the actors you want to bundle. Each actor should be listed on a separate line. Lines starting with `#` are treated as comments and will be ignored. Feel free to add or remove actors as needed for your specific needs.
+
+4. Build the RPM package by running the following command:
+
+- For upgrade between RHEL 7 and RHEL 8:
+
+    ```bash
+    make rpmbuild DIST_VERSION=7
+    ```
+
+- For upgrade between RHEL 8 and RHEL 9:
+
+    ```bash
+    make rpmbuild DIST_VERSION=8
+    ```
+
+After the process is complete, you should see the generated RPM files in the current directory.
+
+### Installing the RPM
+
+To install the custom actors RPM, run the following command:
+```bash
+sudo yum install ./<generated_rpm_file>
+```
+
+Replace `<generated_rpm_file>` with the actual RPM file generated in the previous step. Its name should end with `.noarch.rpm`.
+
+### Using the Custom Actors
+
+Once the RPM is installed, the custom actors are automatically integrated with the Leapp project. You can now perform in-place upgrades using the Leapp command-line interface. The custom actors from this repository will be used during the upgrade process. For more details, they can be seen installed under `/usr/share/leapp-repository/custom-repositories/system_upgrade_supplements`.
+
+For more information on using Leapp and performing in-place upgrades, please refer to the [Leapp documentation](https://leapp.readthedocs.io/) and relevant Red Hat documentation regarding RHEL upgrades.
+
+## Contributing
+
+Section containing details about how to contribute to the project.
+
+Before writing any code, familiarize yourself with the [Leapp project documentation](https://leapp.readthedocs.io/en/latest/). The section — [Creating your first actor](https://leapp.readthedocs.io/en/latest/first-actor.html) — is a good place to start.

--- a/README.md
+++ b/README.md
@@ -110,4 +110,4 @@ For more information on using Leapp and performing in-place upgrades, please ref
 
 Section containing details about how to contribute to the project.
 
-Before writing any code, familiarize yourself with the [Leapp project documentation](https://leapp.readthedocs.io/en/latest/). The section — [Creating your first actor](https://leapp.readthedocs.io/en/latest/first-actor.html) — is a good place to start.
+Before writing any code, familiarize yourself with the [Leapp project documentation](https://leapp.readthedocs.io/en/latest/). The section [Creating your first actor](https://leapp.readthedocs.io/en/latest/first-actor.html) is a good place to start. You should also dig around the [Leapp Dashboard](https://oamg.github.io/leapp-dashboard/#/) to make sure the custom actor functionality you are considering doesn't already exist in the mainstream framework.

--- a/actor-list.txt
+++ b/actor-list.txt
@@ -1,0 +1,2 @@
+# This file contains the list of actors to be installed, each actor on its own line
+checkreboothygiene

--- a/packaging/leapp-supplements.spec
+++ b/packaging/leapp-supplements.spec
@@ -1,0 +1,99 @@
+# Define macros
+%define leapp_datadir %{_datadir}/leapp-repository
+%define repositorydir %{leapp_datadir}/repositories
+%define custom_repositorydir %{leapp_datadir}/custom-repositories
+%define supplementsdir_name system_upgrade_supplements
+%define supplementsdir %{custom_repositorydir}/%{supplementsdir_name}
+
+# Define RPM Preamble
+Name:           leapp-upgrade-el%{rhel}toel%{nextrhel}-supplements
+Version:        1.0.0
+Release:        1%{?dist}
+Summary:        Custom actors for the Leapp project
+
+License:        MIT
+URL:            https://github.com/oamg/%{pkgname}
+Source0:        %{pkgname}-%{version}.tar.gz
+
+BuildArch:      noarch
+
+%if 0%{?rhel} == 7
+### RHEL 7 ###
+BuildRequires:  python-devel
+
+Requires:       leapp
+Requires:       python2-leapp
+# Dependency on leapp-repository
+Requires:       leapp-upgrade-el7toel8
+%endif
+
+%if 0%{?rhel} == 8
+### RHEL 8 ###
+BuildRequires:  python3-devel
+
+Requires:       leapp
+Requires:       python3-leapp
+# Dependency on leapp-repository
+Requires:       leapp-upgrade-el8toel9
+%endif
+
+%description
+Custom leapp actors for the in-place upgrade to the next major version
+of the Red Hat Enterprise Linux system.
+
+%prep
+%autosetup -n %{pkgname}-%{version}
+
+%install
+install -m 0755 -d %{buildroot}%{custom_repositorydir}
+install -m 0755 -d %{buildroot}%{repositorydir}
+install -m 0755 -d %{buildroot}%{supplementsdir}
+install -m 0755 -d %{buildroot}%{_sysconfdir}/leapp/repos.d/
+cp -r repos/%{supplementsdir_name}/* %{buildroot}%{supplementsdir}
+
+# Remove irrelevant repositories - We don't want to ship them for the particular RHEL version
+%if 0%{?rhel} == 7
+rm -rf %{buildroot}%{supplementsdir}/el8toel9
+%endif
+%if 0%{?rhel} == 8
+rm -rf %{buildroot}%{supplementsdir}/el7toel8
+%endif
+
+# Remove empty directories
+find %{buildroot}%{supplementsdir}/ -type d -depth -empty -delete
+
+# Remove actors not found in actors_to_install list
+find %{buildroot}%{supplementsdir}/ -name actor.py -exec dirname {} \;  > tmp_actor_paths
+while read -r actor_path; do
+  actor_name=$(basename "$actor_path")
+  # Check if actors is in actors_to_install list, if not: remove it
+  echo "%{actors_to_install}" | grep -qw "${actor_name}" || rm -rf "$actor_path"
+done < tmp_actor_paths
+rm -f tmp_actor_paths
+
+# Remove component/unit tests
+rm -rf `find %{buildroot}%{supplementsdir} -name "tests" -type d`
+find %{buildroot}%{repositorydir} -name "Makefile" -delete
+
+# Create symlink to the supplements repository
+ln -s %{supplementsdir} %{buildroot}%{_sysconfdir}/leapp/repos.d/%{supplementsdir_name}
+
+# === Compile Python files ===
+# __python2 could be problematic on systems with Python3 only, but we have
+# no choice as __python became error on F33+:
+# - https://fedoraproject.org/wiki/Changes/PythonMacroError
+%if 0%{?rhel} == 7
+%py_byte_compile %{__python2} %{buildroot}%{repositorydir}/*
+%endif
+%if 0%{?rhel} == 8
+%py_byte_compile %{__python3} %{buildroot}%{repositorydir}/*
+%endif
+
+%files
+%{supplementsdir}/*
+%{_sysconfdir}/leapp/repos.d/%{supplementsdir_name}
+
+%changelog
+* Wed May 10 2023 Marek Filip <mafilip@redhat.com>
+- First iteration of the packaging spec file
+- Allow to install actors based on actors_to_install list

--- a/packaging/leapp-supplements.spec
+++ b/packaging/leapp-supplements.spec
@@ -11,7 +11,7 @@ Version:        1.0.0
 Release:        1%{?dist}
 Summary:        Custom actors for the Leapp project
 
-License:        MIT
+License:        ASL 2.0
 URL:            https://github.com/oamg/%{pkgname}
 Source0:        %{pkgname}-%{version}.tar.gz
 


### PR DESCRIPTION
OAMG-8807

### Uknowns / Questions

- Is changing actor lines in `actor-list.txt` a good approach for customers?
- Should I remove SRPM from the final build? (I guess only RPM is needed)

### Done
- test e2e experience (rpmbuild, install, preupgrade - custom inhibitors)
  - upgrade inhibited with correct reports on rhel7 machine

### Details

Inspired from leapp-repository [spec file](https://github.com/oamg/leapp-repository/blob/master/packaging/leapp-repository.spec) and [makefile](https://github.com/oamg/leapp-repository/blob/master/Makefile)

Depending on the DIST_VERSION env var, either RHEL7 or RHEL8 upgrade repositories are created under `/usr/share/leapp-repositories/repositories/system_upgrade_supplements`

Run `make rpmbuild` to install the default RHEL7 supplement repos. Run `make rpmbuild DIST_VERSION=8` for RHEL8 version.

This pull request introduces RPM packaging for custom actors of the repository. The changes include an updated Makefile, a new specfile, an actor-list.txt file to manage the actors to be included in the RPM, and an updated README.md.

The Makefile now supports building RPMs for custom actors on both RHEL 7 and RHEL 8. The specfile is designed to package the custom actors into an RPM, and the actor-list.txt file allows maintainers to add or remove actors that should be included in the RPM.

The README.md file has been updated with a new section that provides detailed build instructions and prerequisites for users who want to package their custom actors into an RPM.

Change license from MIT to Apache 2.0 to be consistent with leapp-repository.
