### PR TITLE
Ignore kdump.img files in CheckRebootHygiene actor

### DIFF
--- a/repos/system_upgrade_supplements/common/actors/checkreboothygiene/libraries/checkreboothygiene.py
+++ b/repos/system_upgrade_supplements/common/actors/checkreboothygiene/libraries/checkreboothygiene.py
@@ -1,5 +1,6 @@
 import os
 import time
+import fnmatch
 
 from leapp import reporting
 from leapp.exceptions import StopActorExecutionError
@@ -80,11 +81,18 @@ def check_mismatched_kernel_versions():
 
 
 def check_modified_boot_files():
+    """
+    Check for modified files on the /boot partition since the last reboot.
+
+    *kdump.img files are excluded from the check, see https://github.com/oamg/leapp-supplements/issues/3
+    for more details.
+    """
     boot_files = []
     for root, _, files in os.walk("/boot"):
         for file in files:
             file_path = os.path.join(root, file)
-            if os.path.isfile(file_path):
+            # We don't want to include the kdump file in the list of boot files
+            if os.path.isfile(file_path) and not fnmatch.fnmatch(file, "*kdump.img"):
                 boot_files.append(file_path)
 
     modified_boot_files = []

--- a/repos/system_upgrade_supplements/common/actors/checkreboothygiene/tests/unit_test_checkreboothygiene.py
+++ b/repos/system_upgrade_supplements/common/actors/checkreboothygiene/tests/unit_test_checkreboothygiene.py
@@ -53,17 +53,19 @@ def test_mismatched_kernel_versions(booted_kernel, default_kernel, inhibit, monk
 
 
 @pytest.mark.parametrize(
-    "uptime_seconds, since_modified_seconds, inhibit",
+    "boot_files, uptime_seconds, since_modified_seconds, inhibit",
     (
-        (0, 1, False),
-        (0, 3600, False),
-        (3600, 0, True),
-        (3601, 3600, True),
+        (["file1", "file2"], 0, 1, False),
+        (["file1", "file2"], 0, 3600, False),
+        (["file1", "file2"], 3600, 0, True),
+        (["file1", "file2"], 3601, 3600, True),
+        (["initramfs-3.10.0-1160.90.1.el7.x86_64kdump.img", "knother.kdump.img"], 0, 3600, False),
+        (["initramfs-3.10.0-1160.90.1.el7.x86_64kdump.img", "another.kdump.img"], 3600, 0, False),
     ),
 )
-def test_modified_boot_files(uptime_seconds, since_modified_seconds, inhibit, monkeypatch):
+def test_modified_boot_files(boot_files, uptime_seconds, since_modified_seconds, inhibit, monkeypatch):
     monkeypatch.setattr(reporting, "create_report", create_report_mocked())
-    monkeypatch.setattr(os, "walk", lambda _: [("/boot", [], ["file1", "file2"])])
+    monkeypatch.setattr(os, "walk", lambda _: [("/boot", [], boot_files)])
     monkeypatch.setattr(os.path, "isfile", lambda _: True)
 
     monkeypatch.setattr(checkreboothygiene, "_get_uptime", lambda: uptime_seconds)


### PR DESCRIPTION
ref: https://github.com/oamg/leapp-supplements/issues/3 

kdumpctl builds the image at boot time if no kdump initial ramdisk found - this can be confusing for users running the actor