### PR TITLE
Make excessive uptime makefile parameterized

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 DIST_VERSION ?= 7
+EXCESSIVE_UPTIME_LIMIT_DAYS ?= 30
 
 PKGNAME := leapp-supplements
 VERSION=$(shell grep -m1 "^Version:" packaging/$(PKGNAME).spec | grep -om1 "[0-9].[0-9.]*")
@@ -30,7 +31,8 @@ rpmbuild: prepare
 		--define "rhel $(DIST_VERSION)" \
 		--define "nextrhel $$(($(DIST_VERSION) + 1))" \
 		--define "dist .el$(DIST_VERSION)" \
-		--define "actors_to_install $(ACTORS_TO_INSTALL)"
+		--define "actors_to_install $(ACTORS_TO_INSTALL)" \
+		--define "excessive_uptime_limit_days $(EXCESSIVE_UPTIME_LIMIT_DAYS)"
 	cp packaging/RPMS/*/*.rpm .
 	cp packaging/SRPMS/*.rpm .
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ The actor will report inhibitor risk when:
 * The running kernel version does not match the default kernel version configured in the bootloader.
 * Any files are found under /boot that have been modified since the last reboot.
 
+**Parameterizing excessive uptime limit**
+
+The actor can be parameterized to set the maximum uptime limit in days after which the upgrade is inhibited.
+The default value is 30 days. To change it to 60 days, for example, call the `make rpmbuild` command with the `EXCESSIVE_UPTIME_LIMIT_DAYS` parameter:
+
+```bash
+make rpmbuild EXCESSIVE_UPTIME_LIMIT_DAYS=60
+```
+
 ## Building the Custom Actors RPM
 
 In order to bundle the custom actors from this Git repository, follow the instructions below.

--- a/packaging/leapp-supplements.spec
+++ b/packaging/leapp-supplements.spec
@@ -51,6 +51,9 @@ install -m 0755 -d %{buildroot}%{supplementsdir}
 install -m 0755 -d %{buildroot}%{_sysconfdir}/leapp/repos.d/
 cp -r repos/%{supplementsdir_name}/* %{buildroot}%{supplementsdir}
 
+# Change excessive uptime limit for checkreboothygiene actor if it was parameterized
+sed -i "s/\(EXCESSIVE_UPTIME_LIMIT_DAYS = \).*/\1%{excessive_uptime_limit_days}/" %{buildroot}%{supplementsdir}/common/actors/checkreboothygiene/libraries/checkreboothygiene.py
+
 # Remove irrelevant repositories - We don't want to ship them for the particular RHEL version
 %if 0%{?rhel} == 7
 rm -rf %{buildroot}%{supplementsdir}/el8toel9

--- a/repos/system_upgrade_supplements/common/actors/checkreboothygiene/libraries/checkreboothygiene.py
+++ b/repos/system_upgrade_supplements/common/actors/checkreboothygiene/libraries/checkreboothygiene.py
@@ -8,7 +8,8 @@ from leapp.libraries.common import config
 from leapp.libraries.stdlib import CalledProcessError, api, run
 
 DAY_IN_SECONDS = 24 * 60 * 60
-# TODO: can this be parametrized? (Makefile)
+# NOTE: This value can be parameterized during rpmbuild in Makefile.
+#       If changing following name/value, make sure to update other places as well.
 EXCESSIVE_UPTIME_LIMIT_DAYS = 30
 EXCESSIVE_UPTIME_LIMIT_SECONDS = EXCESSIVE_UPTIME_LIMIT_DAYS * DAY_IN_SECONDS
 


### PR DESCRIPTION
Other option to parameterize is in #5 

Calling rpmbuild with EXCESSIVE_UPTIME_LIMIT_DAYS will change the value
of uptime check of the final RPM, e.g.:
```
make rpmbuild EXCESSIVE_UPTIME_LIMIT_DAYS=60
```

Add this info to readme and NOTE comment to the original actor file.